### PR TITLE
Added comment that will enable Bearer tokens to work in an IIS/IISExpress

### DIFF
--- a/MinimalOwinWebApiSelfHost/Startup.cs
+++ b/MinimalOwinWebApiSelfHost/Startup.cs
@@ -46,6 +46,8 @@ namespace MinimalOwinWebApiSelfHost
                 "DefaultApi",
                 "api/{controller}/{id}",
                 new { id = RouteParameter.Optional });
+            // Uncomment the following line to use when hosted in IIS/IISExpress (add Microsoft.AspNet.WebApi.Owin nuget package)
+            //config.Filters.Add(new System.Web.Http.HostAuthenticationFilter("Bearer"));
             return config;
         }
     }


### PR DESCRIPTION
I understand this branch is strictly for a self-hosted environment, but this might have saved me some time, hopefully it'll save your readers some time too.

Again thanks for a [great article](http://typecastexception.com/post/2015/01/19/ASPNET-Web-Api-Understanding-OWINKatana-AuthenticationAuthorization-Part-I-Concepts.aspx) :clap: 

I wholeheartedly apologise if the pull request is not welcome.
